### PR TITLE
Standarize decimal responses

### DIFF
--- a/packages/swapper-nodechain-client/src/__tests__/SwapperNodechainClient.test.ts
+++ b/packages/swapper-nodechain-client/src/__tests__/SwapperNodechainClient.test.ts
@@ -26,7 +26,7 @@ describe('SwapperNodechainClient', () => {
       expect(result).toMatchSnapshot()
     })
     it('getBlockByNumber', async () => {
-      const result = await ethClient.getBlockByNumber({ blockNumber: '1' })
+      const result = await ethClient.getBlockByNumber({ blockNumber: 1 })
       expect(result).toMatchSnapshot()
     })
     it('getBlockByHash', async () => {
@@ -103,7 +103,7 @@ describe('SwapperNodechainClient', () => {
       expect(result).toMatchSnapshot()
     })
     it('getBlockByNumber', async () => {
-      const result = await btcClient.getBlockByNumber({ blockNumber: '1' })
+      const result = await btcClient.getBlockByNumber({ blockNumber: 1 })
       expect(result).toMatchSnapshot()
     })
     it('getBlockByHash', async () => {
@@ -135,7 +135,7 @@ describe('SwapperNodechainClient', () => {
       expect(result).toMatchSnapshot()
     })
     xit('getFeePerByte', async () => {
-      const result = await btcClient.getFeePerByte({ confirmations: '1' })
+      const result = await btcClient.getFeePerByte({ confirmations: 1 })
       expect(result).toMatchSnapshot()
     })
     xit('broadcastTransaction', async () => {

--- a/packages/swapper-nodechain-client/src/__tests__/__snapshots__/SwapperNodechainClient.test.ts.snap
+++ b/packages/swapper-nodechain-client/src/__tests__/__snapshots__/SwapperNodechainClient.test.ts.snap
@@ -1935,7 +1935,7 @@ Object {
   "id": 1,
   "jsonrpc": "2.0",
   "result": Object {
-    "broadcasted": "0xe53a38c00f43f001e106aa6d2fc24df2ab56a5c441cfc90d0bcf68fa69d919a6",
+    "broadcasted": "0x4c48389fbd3a048f40a0a3bcbf8e210caa58ab305dfd290810dee8ca53aace08",
   },
 }
 `;
@@ -1945,7 +1945,7 @@ Object {
   "id": 1,
   "jsonrpc": "2.0",
   "result": Object {
-    "estimatedGas": "0x5208",
+    "estimatedGas": 21000,
   },
 }
 `;
@@ -1955,8 +1955,11 @@ Object {
   "id": 1,
   "jsonrpc": "2.0",
   "result": Object {
-    "confirmed": "0x56bc75e2d630e13d0",
-    "unconfirmed": "0x0",
+    "address": "0x625ACaEdeF812d2842eFd2Fb0294682A868455bd",
+    "balance": Object {
+      "confirmed": 99999999999999850000,
+      "unconfirmed": 0,
+    },
   },
 }
 `;
@@ -1969,15 +1972,15 @@ Object {
     Object {
       "address": "0x625ACaEdeF812d2842eFd2Fb0294682A868455bd",
       "balance": Object {
-        "confirmed": "0x56bc75e2d630e13d0",
-        "unconfirmed": "0x0",
+        "confirmed": 99999999999999850000,
+        "unconfirmed": 0,
       },
     },
     Object {
       "address": "0x93261B4021dbd6200Df9B36B151f4ECF34889e94",
       "balance": Object {
-        "confirmed": "0x56bc75e2d63100000",
-        "unconfirmed": "0x0",
+        "confirmed": 100000000000000000000,
+        "unconfirmed": 0,
       },
     },
   ],
@@ -1992,15 +1995,15 @@ Object {
     Object {
       "address": "0x625ACaEdeF812d2842eFd2Fb0294682A868455bd",
       "balance": Object {
-        "confirmed": "0x56bc75e2d630e13d0",
-        "unconfirmed": "0x0",
+        "confirmed": 99999999999999850000,
+        "unconfirmed": 0,
       },
     },
     Object {
       "address": "0x93261B4021dbd6200Df9B36B151f4ECF34889e94",
       "balance": Object {
-        "confirmed": "0x56bc75e2d63100000",
-        "unconfirmed": "0x0",
+        "confirmed": 100000000000000000000,
+        "unconfirmed": 0,
       },
     },
   ],
@@ -2041,7 +2044,7 @@ Object {
   "result": Object {
     "transactions": Array [
       Object {
-        "blockHash": "0x18bfb01b9291729857e8ee107fd01f62e71ca541ed435c23ee0e251461a5dbef",
+        "blockHash": "0xd81ea58f00b6406eac619d909dc7f2d67fe2eca8e2c3ec0d50b57c6a1ab9484f",
         "blockNumber": "0x1",
         "from": "0x625acaedef812d2842efd2fb0294682a868455bd",
         "gas": "0x1e8480",
@@ -2066,7 +2069,7 @@ Object {
   "id": 1,
   "jsonrpc": "2.0",
   "result": Object {
-    "gasPrice": "0x4a817c800",
+    "gasPrice": 20000000000,
   },
 }
 `;
@@ -2076,8 +2079,8 @@ Object {
   "id": 1,
   "jsonrpc": "2.0",
   "result": Object {
-    "latestBlockHash": "0x97af82717ff76daebfdf175bf89db376e18313a6e3b827be8e57da13fbbde5c1",
-    "latestBlockIndex": "0x6",
+    "latestBlockHash": "0xf4bb07646e3d46eae490da5b436510b9dc9239890ecacefa03ab388d212add9a",
+    "latestBlockIndex": 7,
   },
 }
 `;
@@ -2090,17 +2093,17 @@ Object {
     "inputs": Array [
       Object {
         "address": "0x625acaedef812d2842efd2fb0294682a868455bd",
-        "amount": "0x0",
+        "amount": 0,
       },
     ],
     "outputs": Array [
       Object {
         "address": "0x625acaedef812d2842efd2fb0294682a868455bd",
-        "amount": "0x0",
+        "amount": 0,
       },
     ],
     "transaction": Object {
-      "blockHash": "0xad5b1747a8233dbb1e0ca2a73c5453545e2855b2a7a6f49525056da6701dae9b",
+      "blockHash": "0x2848be8e5c1c0414d47fbd437d3864eb369566135c9c2aabaf265eba4a96eb62",
       "blockNumber": "0x2",
       "from": "0x625acaedef812d2842efd2fb0294682a868455bd",
       "gas": "0x1e8480",
@@ -2124,7 +2127,7 @@ Object {
   "id": 1,
   "jsonrpc": "2.0",
   "result": Object {
-    "transactionCount": "0x6",
+    "transactionCount": 7,
   },
 }
 `;
@@ -2134,7 +2137,7 @@ Object {
   "id": 1,
   "jsonrpc": "2.0",
   "result": Object {
-    "blockHash": "0xad5b1747a8233dbb1e0ca2a73c5453545e2855b2a7a6f49525056da6701dae9b",
+    "blockHash": "0x2848be8e5c1c0414d47fbd437d3864eb369566135c9c2aabaf265eba4a96eb62",
     "blockNumber": "0x2",
     "contractAddress": null,
     "cumulativeGasUsed": "0x5208",

--- a/packages/swapper-nodechain-client/src/clients/SwapperNodechainBtcClient.ts
+++ b/packages/swapper-nodechain-client/src/clients/SwapperNodechainBtcClient.ts
@@ -25,7 +25,8 @@ import {
   ResponseGetTransactionBtc,
   ResponseGetTransactionHex,
   ResponseGetAddressHistory,
-  ResponseBroadcastTransaction
+  ResponseBroadcastTransaction,
+  ResponseGetFeePerByte
 } from './types'
 
 export default class SwapperNodechainBtcClient implements ISwapperNodechainClient {
@@ -54,7 +55,7 @@ export default class SwapperNodechainBtcClient implements ISwapperNodechainClien
     return this.client.post('/rpc', this.buildPayload(requestPayload, 'broadcastTransaction'))
   }
 
-  public getFeePerByte (requestPayload: RequestGetFeePerByte): Promise<object> {
+  public getFeePerByte (requestPayload: RequestGetFeePerByte): Promise<ResponseGetFeePerByte> {
     return this.client.post('/rpc', this.buildPayload(requestPayload, 'getFeePerByte'))
   }
 

--- a/packages/swapper-nodechain-client/src/clients/interfaces/ISwapperNodechainClient.ts
+++ b/packages/swapper-nodechain-client/src/clients/interfaces/ISwapperNodechainClient.ts
@@ -17,6 +17,7 @@ import {
   ResponseGetTransactionHex,
   ResponseGetAddressHistory,
   ResponseBroadcastTransaction,
+  ResponseGetFeePerByte,
   // REQUEST
   RequestGetBlockByNumber,
   RequestGetFeePerByte,
@@ -45,7 +46,7 @@ export default interface ISwapperNodechainClient {
     getAddressUnspent?(requestPayload: RequestGetAddressUnspent): Promise<ResponseGetAddressUnspent>
     getTransactionHex?(requestPayload: RequestGetTransaction): Promise<ResponseGetTransactionHex>
     getAddressHistory?(requestPayload: RequestGetAddressHistory): Promise<ResponseGetAddressHistory>
-    getFeePerByte?(requestPayload: RequestGetFeePerByte): Promise<object>
+    getFeePerByte?(requestPayload: RequestGetFeePerByte): Promise<ResponseGetFeePerByte>
     // ETH Methods
     getGasPrice?(): Promise<ResponseGetGasPrice>
     getTransactionReceipt?(requestPayload: RequestGetTransactionReceipt): Promise<ResponseGetTransactionReceipt>

--- a/packages/swapper-nodechain-client/src/clients/types/index.ts
+++ b/packages/swapper-nodechain-client/src/clients/types/index.ts
@@ -13,6 +13,7 @@ import { ResponseGetTransactionBtc, ResponseGetTransactionEth } from './response
 import { ResponseGetTransactionHex } from './responses/ResponseGetTransactionHex'
 import { ResponseGetAddressHistory } from './responses/ResponseGetAddressHistory'
 import { ResponseBroadcastTransaction } from './responses/ResponseBroadcastTransaction'
+import { ResponseGetFeePerByte } from './responses/ResponseGetFeePerByte'
 // REQUESTS
 import { RequestGetAddressBalance } from './requests/RequestGetAddressBalance'
 import { RequestBroadcastTransaction } from './requests/RequestBroadcastTransaction'
@@ -44,6 +45,7 @@ export {
   ResponseGetTransactionEth,
   ResponseGetTransactionHex,
   ResponseGetAddressHistory,
+  ResponseGetFeePerByte,
   ResponseBroadcastTransaction,
   RequestGetAddressBalance,
   RequestBroadcastTransaction,

--- a/packages/swapper-nodechain-client/src/clients/types/index.ts
+++ b/packages/swapper-nodechain-client/src/clients/types/index.ts
@@ -6,7 +6,7 @@ import { ResponseGetBlockByHashBtc, ResponseGetBlockByHashEth } from './response
 import { ResponseGetTransactionCount } from './responses/ResponseGetTransactionCount'
 import { ResponseGetGasPrice } from './responses/ResponseGetGasPrice'
 import { ResponseGetAddressUnspent } from './responses/ResponseGetAddressUnspent'
-import { ResponseGetAddressesBalance } from './responses/ResponseGetAddressesBalance'
+import { ResponseGetAddressesBalance, AddressBalance } from './responses/ResponseGetAddressesBalance'
 import { ResponseGetTransactionReceipt } from './responses/ResponseGetTransactionReceipt'
 import { ResponseEstimateGas } from './responses/ResponseEstimateGas'
 import { ResponseGetTransactionBtc, ResponseGetTransactionEth } from './responses/ResponseGetTransaction'
@@ -30,6 +30,7 @@ import { RequestGetAddressHistory } from './requests/RequestGetAddressHistory'
 
 export {
   ResponseGetAddressBalance,
+  AddressBalance,
   ResponseGetHeight,
   ResponseGetBlockByNumberBtc,
   ResponseGetBlockByNumberEth,

--- a/packages/swapper-nodechain-client/src/clients/types/requests/RequestGetBlockByNumber.ts
+++ b/packages/swapper-nodechain-client/src/clients/types/requests/RequestGetBlockByNumber.ts
@@ -1,3 +1,3 @@
 export type RequestGetBlockByNumber = {
-    blockNumber: string;
+    blockNumber: string | number;
 };

--- a/packages/swapper-nodechain-client/src/clients/types/requests/RequestGetFeePerByte.ts
+++ b/packages/swapper-nodechain-client/src/clients/types/requests/RequestGetFeePerByte.ts
@@ -1,3 +1,3 @@
 export type RequestGetFeePerByte = {
-    confirmations: string;
+    confirmations: number;
 };

--- a/packages/swapper-nodechain-client/src/clients/types/responses/ResponseEstimateGas.ts
+++ b/packages/swapper-nodechain-client/src/clients/types/responses/ResponseEstimateGas.ts
@@ -1,6 +1,6 @@
 import { BaseResponse } from './BaseResponse'
 export type ResponseEstimateGas = BaseResponse & {
     result: {
-        estimatedGas: string
+        estimatedGas: number
     };
 };

--- a/packages/swapper-nodechain-client/src/clients/types/responses/ResponseGetAddressBalance.ts
+++ b/packages/swapper-nodechain-client/src/clients/types/responses/ResponseGetAddressBalance.ts
@@ -1,7 +1,7 @@
 import { BaseResponse } from './BaseResponse'
 export type ResponseGetAddressBalance = BaseResponse & {
     result: {
-        confirmed: string,
-        unconfirmed: string
+        confirmed: number,
+        unconfirmed: number
     };
 };

--- a/packages/swapper-nodechain-client/src/clients/types/responses/ResponseGetAddressUnspent.ts
+++ b/packages/swapper-nodechain-client/src/clients/types/responses/ResponseGetAddressUnspent.ts
@@ -1,15 +1,15 @@
 import { BaseResponse } from './BaseResponse'
 
 type UtxoStatus = {
-    blockHeight: string,
+    blockHeight: number,
     confirmed: boolean,
 }
 
 type Utxo = {
     status: UtxoStatus,
     txHash: string,
-    value: string,
-    vout: string,
+    value: number,
+    vout: number,
 }
 
 export type ResponseGetAddressUnspent = BaseResponse & {

--- a/packages/swapper-nodechain-client/src/clients/types/responses/ResponseGetAddressesBalance.ts
+++ b/packages/swapper-nodechain-client/src/clients/types/responses/ResponseGetAddressesBalance.ts
@@ -3,7 +3,7 @@ type Balance = {
     confirmed: number,
     unconfirmed: number,
 }
-type AddressBalance = {
+export type AddressBalance = {
     address: string,
     balance: Balance
 }

--- a/packages/swapper-nodechain-client/src/clients/types/responses/ResponseGetAddressesBalance.ts
+++ b/packages/swapper-nodechain-client/src/clients/types/responses/ResponseGetAddressesBalance.ts
@@ -1,7 +1,7 @@
 import { BaseResponse } from './BaseResponse'
 type Balance = {
-    confirmed: string,
-    unconfirmed: string,
+    confirmed: number,
+    unconfirmed: number,
 }
 type AddressBalance = {
     address: string,

--- a/packages/swapper-nodechain-client/src/clients/types/responses/ResponseGetFeePerByte.ts
+++ b/packages/swapper-nodechain-client/src/clients/types/responses/ResponseGetFeePerByte.ts
@@ -1,0 +1,6 @@
+import { BaseResponse } from './BaseResponse'
+export type ResponseGetFeePerByte = BaseResponse & {
+    result: {
+        feePerByte: number
+    }
+}

--- a/packages/swapper-nodechain-client/src/clients/types/responses/ResponseGetGasPrice.ts
+++ b/packages/swapper-nodechain-client/src/clients/types/responses/ResponseGetGasPrice.ts
@@ -1,6 +1,6 @@
 import { BaseResponse } from './BaseResponse'
 export type ResponseGetGasPrice = BaseResponse & {
     result: {
-        gasPrice: string
+        gasPrice: number
     }
 }

--- a/packages/swapper-nodechain-client/src/clients/types/responses/ResponseGetHeight.ts
+++ b/packages/swapper-nodechain-client/src/clients/types/responses/ResponseGetHeight.ts
@@ -2,6 +2,6 @@ import { BaseResponse } from './BaseResponse'
 export type ResponseGetHeight = BaseResponse & {
     result: {
         latestBlockHash: string,
-        latestBlockIndex: string
+        latestBlockIndex: number
     };
 };

--- a/packages/swapper-nodechain-client/src/clients/types/responses/ResponseGetTransaction.ts
+++ b/packages/swapper-nodechain-client/src/clients/types/responses/ResponseGetTransaction.ts
@@ -18,12 +18,12 @@ export type ResponseGetTransactionBtc = BaseResponse & {
 
 type input = {
     address: string,
-    amount: string
+    amount: number
 }
 
 type output = {
     address: string,
-    amount: string
+    amount: number
 }
 
 export type ResponseGetTransactionEth = BaseResponse & {

--- a/packages/swapper-nodechain-client/src/clients/types/responses/ResponseGetTransactionCount.ts
+++ b/packages/swapper-nodechain-client/src/clients/types/responses/ResponseGetTransactionCount.ts
@@ -1,6 +1,6 @@
 import { BaseResponse } from './BaseResponse'
 export type ResponseGetTransactionCount = BaseResponse & {
     result: {
-        transactionCount: string
+        transactionCount: number
     };
 };

--- a/packages/swapper-wallets/__mocks__/@swapper-org/swapper-nodechain-client.ts
+++ b/packages/swapper-wallets/__mocks__/@swapper-org/swapper-nodechain-client.ts
@@ -13,22 +13,22 @@ export class SwapperNodechainEthClient {
   }
 
   public getGasPrice (): Promise<ResponseGetGasPrice> {
-    const response: ResponseGetGasPrice = { id: 1, jsonrpc: 'getGasPrice', result: { gasPrice: '0xDEAD' } }
+    const response: ResponseGetGasPrice = { id: 1, jsonrpc: 'getGasPrice', result: { gasPrice: 2000000 } }
     return new Promise((resolve) => resolve(response))
   }
 
   public getTransactionCount (): Promise<ResponseGetTransactionCount> {
-    const response: ResponseGetTransactionCount = { id: 1, jsonrpc: 'getTransactionCount', result: { transactionCount: '0x0' } }
+    const response: ResponseGetTransactionCount = { id: 1, jsonrpc: 'getTransactionCount', result: { transactionCount: 2 } }
     return new Promise((resolve) => resolve(response))
   }
 
   public getAddressesBalance (): Promise<ResponseGetAddressesBalance> {
-    const response: ResponseGetAddressesBalance = { id: 1, jsonrpc: 'getAddressesBalance', result: [{ address: '0xFFF', balance: { confirmed: '0x1', unconfirmed: '0x0' } }] }
+    const response: ResponseGetAddressesBalance = { id: 1, jsonrpc: 'getAddressesBalance', result: [{ address: '0xFFF', balance: { confirmed: 1000000000000000, unconfirmed: 1233221231233123 } }] }
     return new Promise((resolve) => resolve(response))
   }
 
   public estimateGas (): Promise<ResponseEstimateGas> {
-    const response: ResponseEstimateGas = { id: 1, jsonrpc: 'estimateGas', result: { estimatedGas: '0x12313' } }
+    const response: ResponseEstimateGas = { id: 1, jsonrpc: 'estimateGas', result: { estimatedGas: 123123123123 } }
     return new Promise((resolve) => resolve(response))
   }
 }

--- a/packages/swapper-wallets/src/EthWallet/__snapshots__/EthWallet.test.ts.snap
+++ b/packages/swapper-wallets/src/EthWallet/__snapshots__/EthWallet.test.ts.snap
@@ -8,7 +8,7 @@ Array [
 ]
 `;
 
-exports[`EthWallet getBalance 1`] = `"1"`;
+exports[`EthWallet getBalance 1`] = `"1000000000000000"`;
 
 exports[`EthWallet transfer 1`] = `
 Object {


### PR DESCRIPTION
# Task completed

- [x] Change `string` type to `number` type to fit changes in swapper-org/Nodechain#28
- [x] Add missing type for `ResponseGetFeePerByte`

## Important information
This is a **breaking change** test will be modified to fit the new standard.

### PR RELATED
swapper-org/Nodechain#42